### PR TITLE
fix readBmxReg and make R/W public

### DIFF
--- a/DFRobot_BMX160.cpp
+++ b/DFRobot_BMX160.cpp
@@ -252,7 +252,7 @@ int8_t DFRobot_BMX160::readBmxReg(uint8_t reg)
     uint8_t buf[1] = {0};
     
     readReg(reg, buf, sizeof(buf));
-    return buf[1];
+    return buf[0];
 }
 
 void DFRobot_BMX160::writeBmxReg(uint8_t reg, uint8_t value)

--- a/DFRobot_BMX160.cpp
+++ b/DFRobot_BMX160.cpp
@@ -107,7 +107,7 @@ void DFRobot_BMX160::wakeUp(){
 
 bool DFRobot_BMX160::softReset()
 {
-  int8_t rslt=BMX160_OK;
+  uint8_t rslt=BMX160_OK;
   if (Obmx160 == NULL){
     rslt = BMX160_E_NULL_PTR;
   }  
@@ -118,9 +118,9 @@ bool DFRobot_BMX160::softReset()
     return false;
 }
 
-int8_t DFRobot_BMX160::softReset(struct bmx160Dev *dev)
+uint8_t DFRobot_BMX160::softReset(struct bmx160Dev *dev)
 {
-  int8_t rslt=BMX160_OK;
+  uint8_t rslt=BMX160_OK;
   uint8_t data = BMX160_SOFT_RESET_CMD;
   if (dev==NULL){
     rslt = BMX160_E_NULL_PTR;
@@ -247,7 +247,7 @@ void DFRobot_BMX160::getAllData(struct bmx160SensorData *magn, struct bmx160Sens
     }
 }
 
-int8_t DFRobot_BMX160::readBmxReg(uint8_t reg)
+uint8_t DFRobot_BMX160::readBmxReg(uint8_t reg)
 {
     uint8_t buf[1] = {0};
     

--- a/DFRobot_BMX160.h
+++ b/DFRobot_BMX160.h
@@ -1231,7 +1231,7 @@ class DFRobot_BMX160{
      * @brief read bmx160 register
      * @return value in that register
      */
-    int8_t readBmxReg(uint8_t reg);
+    uint8_t readBmxReg(uint8_t reg);
 
     /*
      * @brief write bmx160 register
@@ -1239,7 +1239,7 @@ class DFRobot_BMX160{
     void writeBmxReg(uint8_t reg, uint8_t value);
 
   private:
-    int8_t softReset(struct bmx160Dev *dev);
+    uint8_t softReset(struct bmx160Dev *dev);
     void   defaultParamSettg(struct bmx160Dev *dev);
     float accelRange = BMX160_ACCEL_MG_LSB_2G * 10;
     float gyroRange = BMX160_GYRO_SENSITIVITY_250DPS;

--- a/DFRobot_BMX160.h
+++ b/DFRobot_BMX160.h
@@ -1227,6 +1227,17 @@ class DFRobot_BMX160{
     void setLowPower();
     void wakeUp();
     
+    /*
+     * @brief read bmx160 register
+     * @return value in that register
+     */
+    int8_t readBmxReg(uint8_t reg);
+
+    /*
+     * @brief write bmx160 register
+     */
+    void writeBmxReg(uint8_t reg, uint8_t value);
+
   private:
     int8_t softReset(struct bmx160Dev *dev);
     void   defaultParamSettg(struct bmx160Dev *dev);
@@ -1241,8 +1252,6 @@ class DFRobot_BMX160{
     struct bmx160SensorData* Ogyro; 
     void readReg(uint8_t reg, uint8_t *pBuf, uint16_t len);
     void writeReg(uint8_t reg, uint8_t *pBuf, uint16_t len);
-    int8_t readBmxReg(uint8_t reg);
-    void writeBmxReg(uint8_t reg, uint8_t value);
     bool scan();
 };
 


### PR DESCRIPTION
I didn't test it on I2C, tbh I rewrote it for (4-wire) SPI (do you want me to create a PR for that here too? That you can change from I2C to SPI if required?) but I am very sure, returning the second item of an array of length 1 is wrong. :)

And I would like to request putting readBmxReg and writeBmxReg into public space so I can read and write my custom registers. Right?