### PR TITLE
added support for device address 0x69

### DIFF
--- a/DFRobot_BMX160.cpp
+++ b/DFRobot_BMX160.cpp
@@ -36,8 +36,9 @@ const uint8_t int_mask_lookup_table[13] = {
     BMX160_INT2_FIFO_WM_MASK
 };
 
-bool DFRobot_BMX160::begin()
+bool DFRobot_BMX160::begin(uint8_t device_addr=0x68)
 {
+    _addr=device_addr;
     _pWire->begin();
     if (scan() == true){
         softReset();

--- a/DFRobot_BMX160.h
+++ b/DFRobot_BMX160.h
@@ -984,7 +984,7 @@ class DFRobot_BMX160{
      * @retval true Initialization succeeded
      * @retval false Initialization  failed
      */
-    bool begin();
+    bool begin(uint8_t device_addr=0x68);
 
     /**
      * @fn setGyroRange


### PR DESCRIPTION
Title: Enhance BMX160 Library for Customizable I2C Address Initialization

Description:

Issue: While working with the BMX160 sensor on the Arduino Mega board, I encountered a limitation where using multiple sensors with the default I2C address (0x68) became problematic. The address was hardcoded to _addr=0x68 in the  header file, limiting the flexibility for users requiring multiple sensors.

Solution: To address this, I have made modifications to the BMX160 library:

Updated the begin function to accept an optional argument for the I2C address.
Users now have the flexibility to specify a custom I2C address during sensor initialization or use the default 0x68 address if left unspecified.